### PR TITLE
Use new api/admin/pipeline_groups for getting pipeline groups

### DIFF
--- a/pipeline_group.go
+++ b/pipeline_group.go
@@ -1,8 +1,6 @@
 package gocd
 
 import (
-	"encoding/json"
-
 	multierror "github.com/hashicorp/go-multierror"
 )
 
@@ -22,54 +20,21 @@ type PipelineGroup struct {
 
 // GetPipelineGroups List pipeline groups along with the pipelines, stages and materials for each pipeline.
 func (c *DefaultClient) GetPipelineGroups() ([]*PipelineGroup, error) {
+
+	type EmbeddedObj struct {
+		PipelineGroup []*PipelineGroup `json:"groups"`
+	}
+	type AllPipelineGroupsResponse struct {
+		Embedded EmbeddedObj `json:"_embedded"`
+	}
+	res := new(AllPipelineGroupsResponse)
+	headers := map[string]string{"Accept": "application/vnd.go.cd+json"}
+	err := c.getJSON("/go/api/admin/pipeline_groups", headers, res)
+	if err != nil {
+		return []*PipelineGroup{}, err
+	}
+
 	var errors *multierror.Error
 
-	// Somehow GoCD will return "The resource you requested was not found!" if you specify an Accept header
-	_, body, errs := c.Request.
-		Get(c.resolve("/go/api/config/pipeline_groups")).
-		//Set("Accept", "application/vnd.go.cd.v2+json").
-		End()
-
-	if errs != nil {
-		errors = multierror.Append(errors, errs...)
-		return []*PipelineGroup{}, errors.ErrorOrNil()
-	}
-
-	// first parse the json into temporary structure, so we parse stages object
-	// with a single name string attribute as simple string
-	type tmpStage struct {
-		Name string `json:"name,omitempty"`
-	}
-	type tmpPipeline struct {
-		Name      string     `json:"name,omitempty"`
-		Label     string     `json:"label,omitempty"`
-		Materials []Material `json:"materials,omitempty"`
-		Stages    []tmpStage `json:"stages,omitempty"`
-	}
-
-	type tmpPipelineGroup struct {
-		Name      string        `json:"name,omitempty"`
-		Pipelines []tmpPipeline `json:"pipelines,omitempty"`
-	}
-	var tmpPipelineGroups []tmpPipelineGroup
-
-	jsonErr := json.Unmarshal([]byte(body), &tmpPipelineGroups)
-	if jsonErr != nil {
-		errors = multierror.Append(errors, jsonErr)
-		return []*PipelineGroup{}, errors.ErrorOrNil()
-	}
-	// create the good pipeline groups structures and copy data from the temporary structs
-	pipelineGroups := make([]*PipelineGroup, len(tmpPipelineGroups))
-	for i, pg := range tmpPipelineGroups {
-		pipelineGroups[i] = &PipelineGroup{Name: pg.Name}
-		pipelineGroups[i].Pipelines = make([]Pipeline, len(pg.Pipelines))
-		for j, p := range pg.Pipelines {
-			pipelineGroups[i].Pipelines[j] = Pipeline{Name: p.Name, Label: p.Label, Materials: p.Materials, Stages: make([]string, len(p.Stages))}
-			for k, s := range p.Stages {
-				pipelineGroups[i].Pipelines[j].Stages[k] = s.Name
-			}
-		}
-
-	}
-	return pipelineGroups, errors.ErrorOrNil()
+	return res.Embedded.PipelineGroup, errors.ErrorOrNil()
 }

--- a/pipeline_group_test.go
+++ b/pipeline_group_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestGetPipelineGroups(t *testing.T) {
 	t.Parallel()
-	client, server := newTestAPIClient("/go/api/config/pipeline_groups", serveFileAsJSON(t, "GET", "test-fixtures/get_pipeline_groups.json", 0, DummyRequestBodyValidator))
+	client, server := newTestAPIClient("/go/api/admin/pipeline_groups", serveFileAsJSON(t, "GET", "test-fixtures/get_pipeline_groups.json", 0, DummyRequestBodyValidator))
 	defer server.Close()
 	pipelineGroups, err := client.GetPipelineGroups()
 	assert.NoError(t, err)
@@ -20,12 +20,6 @@ func TestGetPipelineGroups(t *testing.T) {
 	assert.Equal(t, 1, len(pg.Pipelines))
 	p := pg.Pipelines[0]
 	assert.Equal(t, "up42", p.Name)
-	assert.Equal(t, "${COUNT}", p.Label)
-	assert.Equal(t, 1, len(p.Materials))
-	material := p.Materials[0]
-	assert.Equal(t, "2d05446cd52a998fe3afd840fc2c46b7c7e421051f0209c7f619c95bedc28b88", material.Fingerprint)
-	assert.Equal(t, "Git", material.Type)
-	assert.Equal(t, "URL: https://github.com/gocd/gocd, Branch: master", material.Description)
-	assert.Equal(t, 1, len(p.Stages))
-	assert.Equal(t, "up42_stage", p.Stages[0])
+	assert.Empty(t, p.Label)
+	assert.Nil(t, p.Materials)
 }

--- a/test-fixtures/get_pipeline_groups.json
+++ b/test-fixtures/get_pipeline_groups.json
@@ -1,23 +1,53 @@
-[
-  {
-    "pipelines": [
-      {
-        "stages": [
-          {
-            "name": "up42_stage"
+{
+  "_links" : {
+    "self" : {
+      "href" : "https://ci.example.com/go/api/admin/pipeline_groups"
+    },
+    "doc" : {
+      "href" : "https://api.go.cd/current/#pipeline-group-config"
+    },
+    "find" : {
+      "href" : "https://ci.example.com/go/api/admin/pipeline_groups/:group"
+    }
+  },
+  "_embedded" : {
+    "groups" : [ {
+      "_links" : {
+        "self" : {
+          "href" : "https://ci.example.com/go/api/admin/pipeline_groups/first"
+        },
+        "doc" : {
+          "href" : "https://api.go.cd/current/#pipeline-group-config"
+        },
+        "find" : {
+          "href" : "https://ci.example.com/go/api/admin/pipeline_groups/:group"
+        }
+      },
+      "name" : "first",
+      "authorization" : {
+        "view" : {
+          "users" : [ "operate" ],
+          "roles" : [ ]
+        },
+        "admins" : {
+          "users" : [ "operate" ],
+          "roles" : [ ]
+        }
+      },
+      "pipelines" : [ {
+        "_links" : {
+          "self" : {
+            "href" : "https://ci.example.com/go/api/admin/pipelines/up42"
+          },
+          "doc" : {
+            "href" : "https://api.gocd.org/#pipeline-config"
+          },
+          "find" : {
+            "href" : "https://ci.example.com/go/api/admin/pipelines/:pipeline_name"
           }
-        ],
-        "name": "up42",
-        "materials": [
-          {
-            "description": "URL: https://github.com/gocd/gocd, Branch: master",
-            "fingerprint": "2d05446cd52a998fe3afd840fc2c46b7c7e421051f0209c7f619c95bedc28b88",
-            "type": "Git"
-          }
-        ],
-        "label": "${COUNT}"
-      }
-    ],
-    "name": "first"
+        },
+        "name" : "up42"
+      } ]
+    } ]
   }
-]
+}


### PR DESCRIPTION
api/config/pipeline_groups has been deprecated in 20.3.0:
https://api.gocd.org/20.3.0/#api-changelog

By using the api/admin/pipeline_groups endpoint instead we get the same
functionality, however some fields on the pipeline group struct will
never be set but I think this is good enough...