### PR TITLE
Use the newest version of gocd agents job_run_history api.

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -28,6 +28,27 @@ type Agent struct {
 	Env       []string `json:"environments,omitempty"`
 }
 
+type AgentJobHistory struct {
+	Name                string                    `json:"job_name"`
+	JobStateTransitions []AgentJobStateTransition `json:"job_state_transitions"`
+	StageName           string                    `json:"stage_name"`
+	StageCounter        string                    `json:"stage_counter"`
+	PipelineName        string                    `json:"pipeline_name"`
+	PipelineCounter     int                       `json:"pipeline_counter"`
+	Result              string                    `json:"result"`
+	ReRun               bool                      `json:"rerun"`
+}
+
+type AgentJobStateTransition struct {
+	StateChangeTime string `json:"state_change_time,omitempty"`
+	State           string `json:"state,omitempty"`
+}
+
+type AgentJobRunHistory struct {
+	Jobs       []*AgentJobHistory `json:"jobs"`
+	Pagination Pagination         `json:"pagination"`
+}
+
 // FreeSpace is required for GoCD API inconsistencies in agent free space scrape.
 type FreeSpace int
 
@@ -128,9 +149,9 @@ func (c *DefaultClient) DeleteAgent(uuid string) error {
 }
 
 // AgentRunJobHistory - Lists the jobs that have executed on an agent.
-func (c *DefaultClient) AgentRunJobHistory(uuid string, offset int) (*JobRunHistory, error) {
-	res := new(JobRunHistory)
-	headers := map[string]string{"Accept": "application/json"}
-	err := c.getJSON(fmt.Sprintf("/go/api/agents/%s/job_run_history/%d", uuid, offset), headers, res)
+func (c *DefaultClient) AgentRunJobHistory(uuid string, offset int, pageSize int) (*AgentJobRunHistory, error) {
+	res := new(AgentJobRunHistory)
+	headers := map[string]string{"Accept": "application/vnd.go.cd+json"}
+	err := c.getJSON(fmt.Sprintf("/go/api/agents/%s/job_run_history?offset=%d&page_size=%d", uuid, offset, pageSize), headers, res)
 	return res, err
 }

--- a/agent_test.go
+++ b/agent_test.go
@@ -82,37 +82,31 @@ func TestDeleteAgent(t *testing.T) {
 func TestAgentRunHistory(t *testing.T) {
 	t.Parallel()
 
-	client, server := newTestAPIClient("/go/api/agents/uuid/job_run_history/0", serveFileAsJSON(t, "GET", "test-fixtures/get_agent_run_history.json", 0, DummyRequestBodyValidator))
+	client, server := newTestAPIClient("/go/api/agents/uuid/job_run_history", serveFileAsJSON(t, "GET", "test-fixtures/get_agent_run_history.json", 0, DummyRequestBodyValidator))
 	defer server.Close()
-	history, err := client.AgentRunJobHistory("uuid", 0)
+	history, err := client.AgentRunJobHistory("uuid", 0, 50)
 	assert.NoError(t, err)
 	jobs := history.Jobs
 	assert.NotNil(t, jobs)
 	assert.Equal(t, 1, len(jobs))
 	job1 := jobs[0]
 	assert.NotNil(t, job1)
-	assert.Equal(t, "5c5c318f-e6d3-4299-9120-7faff6e6030b", job1.AgentUUID)
 	assert.Equal(t, "upload", job1.Name)
-	assert.Equal(t, []JobStateTransition{{
-		StateChangeTime: 1435631497131,
-		ID:              539906,
+	assert.Equal(t, []AgentJobStateTransition{{
+		StateChangeTime: "2019-11-12T00:20:56Z",
 		State:           "Scheduled",
 	}}, job1.JobStateTransitions)
-	assert.Equal(t, 1435631497131, job1.ScheduledDate)
-	assert.Equal(t, "", job1.OriginalJobID)
 	assert.Equal(t, 251, job1.PipelineCounter)
 	assert.Equal(t, false, job1.ReRun)
 	assert.Equal(t, "distributions-all", job1.PipelineName)
 	assert.Equal(t, "Passed", job1.Result)
-	assert.Equal(t, "Completed", job1.State)
-	assert.Equal(t, 100129, job1.ID)
 	assert.Equal(t, "1", job1.StageCounter)
 	assert.Equal(t, "upload-installers", job1.StageName)
 
 	pagination := history.Pagination
 	assert.Equal(t, pagination.Total, 1292)
-	assert.Equal(t, pagination.Offset, 0)
-	assert.Equal(t, pagination.PageSize, 10)
+	assert.Equal(t, pagination.Offset, 10)
+	assert.Equal(t, pagination.PageSize, 50)
 }
 
 func TestFreeSpace(t *testing.T) {

--- a/client.go
+++ b/client.go
@@ -9,7 +9,7 @@ type Client interface {
 	DisableAgent(uuid string) error
 	EnableAgent(uuid string) error
 	DeleteAgent(uuid string) error
-	AgentRunJobHistory(uuid string, offset int) (*JobRunHistory, error)
+	AgentRunJobHistory(uuid string, offset int, pageSize int) (*AgentJobRunHistory, error)
 
 	// Pipeline Groups API
 	GetPipelineGroups() ([]*PipelineGroup, error)

--- a/test-fixtures/get_agent_run_history.json
+++ b/test-fixtures/get_agent_run_history.json
@@ -1,30 +1,32 @@
 {
-  "jobs": [
-    {
-      "agent_uuid": "5c5c318f-e6d3-4299-9120-7faff6e6030b",
-      "name": "upload",
-      "job_state_transitions": [
-        {
-          "state_change_time": 1435631497131,
-          "id": 539906,
-          "state": "Scheduled"
-        }
-      ],
-      "scheduled_date": 1435631497131,
-      "original_job_id": null,
-      "pipeline_counter": 251,
-      "rerun": false,
-      "pipeline_name": "distributions-all",
-      "result": "Passed",
-      "state": "Completed",
-      "id": 100129,
-      "stage_counter": "1",
-      "stage_name": "upload-installers"
+  "_links" : {
+    "doc" : {
+      "href" : "https://api.gocd.org/19.11.0/#agent-job-run-history"
+    },
+    "self" : {
+      "href" : "https://ci.example.com/go/api/agents/adb9540a-b954-4571-9d9b-2f330739d4da/job_run_history"
+    },
+    "find" : {
+      "href" : "https://ci.example.com/go/api/agents/:uuid"
     }
-  ],
-  "pagination": {
-    "offset": 0,
-    "total": 1292,
-    "page_size": 10
+  },
+  "uuid" : "adb9540a-b954-4571-9d9b-2f330739d4da",
+  "jobs" : [ {
+    "job_state_transitions" : [ {
+      "state_change_time" : "2019-11-12T00:20:56Z",
+      "state" : "Scheduled"
+    } ],
+    "job_name" : "upload",
+    "stage_name" : "upload-installers",
+    "stage_counter" : "1",
+    "pipeline_name" : "distributions-all",
+    "pipeline_counter" : 251,
+    "result" : "Passed",
+    "rerun" : false
+  } ],
+  "pagination" : {
+    "page_size" : 50,
+    "offset" : 10,
+    "total" : 1292
   }
 }


### PR DESCRIPTION
The newest version of https://api.gocd.org/20.3.0/#agent-job-run-history
has changed quite a bit. The structure is now different to the regular
job history api which means that we need to create new data structures
specific to agent job history.

There are a few new parameters tot the agent-job-history-api, of which
offset and page_size are two of them. They have been introduced in the
signature of AgentRunJobHistory as well. sort_column and sort_order has
been ignored for now but can be added when there is a need.