### PR TITLE
remove offset from job history api call

### DIFF
--- a/agent_test.go
+++ b/agent_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestGetAllAgents(t *testing.T) {
 	t.Parallel()
-	client, server := newTestAPIClient("/go/api/agents", serveFileAsJSON(t, "GET", "test-fixtures/get_all_agents.json", 6, DummyRequestBodyValidator))
+	client, server := newTestAPIClient("/go/api/agents", serveFileAsJSON(t, "GET", "test-fixtures/get_all_agents.json", 0, DummyRequestBodyValidator))
 	defer server.Close()
 	agents, err := client.GetAllAgents()
 	assert.NoError(t, err)
@@ -32,7 +32,7 @@ func TestGetAllAgents(t *testing.T) {
 
 func TestGetAgent(t *testing.T) {
 	t.Parallel()
-	client, server := newTestAPIClient("/go/api/agents/uuid", serveFileAsJSON(t, "GET", "test-fixtures/get_agent.json", 6, DummyRequestBodyValidator))
+	client, server := newTestAPIClient("/go/api/agents/uuid", serveFileAsJSON(t, "GET", "test-fixtures/get_agent.json", 0, DummyRequestBodyValidator))
 	defer server.Close()
 	agent, err := client.GetAgent("uuid")
 	assert.NoError(t, err)
@@ -59,7 +59,7 @@ func TestUpdateAgent(t *testing.T) {
 		return nil
 	}
 
-	client, server := newTestAPIClient("/go/api/agents/uuid", serveFileAsJSON(t, "PATCH", "test-fixtures/patch_agent.json", 6, requestBodyValidator))
+	client, server := newTestAPIClient("/go/api/agents/uuid", serveFileAsJSON(t, "PATCH", "test-fixtures/patch_agent.json", 0, requestBodyValidator))
 	defer server.Close()
 	var agent = Agent{
 		Hostname: "agent02.example.com",
@@ -73,7 +73,7 @@ func TestUpdateAgent(t *testing.T) {
 func TestDeleteAgent(t *testing.T) {
 	t.Parallel()
 
-	client, server := newTestAPIClient("/go/api/agents/uuid", serveFileAsJSON(t, "DELETE", "test-fixtures/delete_agent.json", 6, DummyRequestBodyValidator))
+	client, server := newTestAPIClient("/go/api/agents/uuid", serveFileAsJSON(t, "DELETE", "test-fixtures/delete_agent.json", 0, DummyRequestBodyValidator))
 	defer server.Close()
 	err := client.DeleteAgent("uuid")
 	assert.NoError(t, err)

--- a/client.go
+++ b/client.go
@@ -24,7 +24,7 @@ type Client interface {
 
 	// Jobs API
 	GetScheduledJobs() ([]*ScheduledJob, error)
-	GetJobHistory(pipeline, stage, job string, offset int) ([]*JobHistory, error)
+	GetJobHistory(pipeline, stage, job string) ([]*JobHistory, error)
 
 	// Environment Config API
 	GetAllEnvironmentConfigs() ([]*EnvironmentConfig, error)

--- a/jobs.go
+++ b/jobs.go
@@ -108,10 +108,10 @@ type JobRunHistory struct {
 }
 
 // GetJobHistory - The job history allows users to list job instances of specified job. Supports pagination using offset which tells the API how many instances to skip.
-func (c *DefaultClient) GetJobHistory(pipeline, stage, job string, offset int) ([]*JobHistory, error) {
+func (c *DefaultClient) GetJobHistory(pipeline, stage, job string) ([]*JobHistory, error) {
 	var errors *multierror.Error
 	_, body, errs := c.Request.
-		Get(c.resolve(fmt.Sprintf("/go/api/jobs/%s/%s/%s/history/%d", pipeline, stage, job, offset))).
+		Get(c.resolve(fmt.Sprintf("/go/api/jobs/%s/%s/%s/history", pipeline, stage, job))).
 		Set("Accept", "application/vnd.go.cd+json").
 		End()
 	if errs != nil {

--- a/jobs_test.go
+++ b/jobs_test.go
@@ -29,9 +29,9 @@ func TestGetScheduledJobs(t *testing.T) {
 
 func TestGetJobHistory(t *testing.T) {
 	t.Parallel()
-	client, server := newTestAPIClient("/go/api/jobs/pipeline/stage/job/history/0", serveFileAsJSON(t, "GET", "test-fixtures/get_job_history.json", 0, DummyRequestBodyValidator))
+	client, server := newTestAPIClient("/go/api/jobs/pipeline/stage/job/history", serveFileAsJSON(t, "GET", "test-fixtures/get_job_history.json", 0, DummyRequestBodyValidator))
 	defer server.Close()
-	jobs, err := client.GetJobHistory("pipeline", "stage", "job", 0)
+	jobs, err := client.GetJobHistory("pipeline", "stage", "job")
 	assert.NoError(t, err)
 	assert.NotNil(t, jobs)
 	assert.Equal(t, 2, len(jobs))
@@ -54,11 +54,11 @@ func TestGetJobHistory(t *testing.T) {
 
 func TestGetJobHistoryError(t *testing.T) {
 	t.Parallel()
-	client, server := newTestAPIClient("/go/api/jobs/pipeline/stage/job/history/0", func(w http.ResponseWriter, _ *http.Request) {
+	client, server := newTestAPIClient("/go/api/jobs/pipeline/stage/job/history", func(w http.ResponseWriter, _ *http.Request) {
 		w.Write([]byte("invalid json"))
 	})
 	defer server.Close()
-	if _, err := client.GetJobHistory("pipeline", "stage", "job", 0); err == nil {
+	if _, err := client.GetJobHistory("pipeline", "stage", "job"); err == nil {
 		t.Error("expected an error")
 	}
 }


### PR DESCRIPTION
As per https://api.gocd.org/current/#get-job-history there is no longer any offset in the api call.
